### PR TITLE
Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-libp2p open source project

--- a/Package.swift
+++ b/Package.swift
@@ -31,11 +31,11 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
 
-        // LibP2P Core Modules
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.2.0")),
+        // LibP2P
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.3.0")),
 
         // NIO Test Utils
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.0.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.87.0")),
 
     ],
     targets: [

--- a/Sources/LibP2PMPLEX/MPLEX/MPLEXErrorCode.swift
+++ b/Sources/LibP2PMPLEX/MPLEX/MPLEXErrorCode.swift
@@ -26,8 +26,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOCore
 import NIOConcurrencyHelpers
+import NIOCore
 
 /// An MPLEX error code.
 public struct MPLEXErrorCode: Sendable {
@@ -46,12 +46,12 @@ public struct MPLEXErrorCode: Sendable {
 
     /// Create a MPELX error code from the given network value.
     public init(networkCode: Int) {
-        self._networkCode = .init( UInt32(networkCode) )
+        self._networkCode = .init(UInt32(networkCode))
     }
 
     /// Create a `MPLEXErrorCode` from the 32-bit integer it corresponds to.
     internal init(_ networkInteger: UInt32) {
-        self._networkCode = .init( networkInteger )
+        self._networkCode = .init(networkInteger)
     }
 
     /// The associated condition is not a result of an error. For example,

--- a/Sources/LibP2PMPLEX/MPLEX/MPLEXErrors.swift
+++ b/Sources/LibP2PMPLEX/MPLEX/MPLEXErrors.swift
@@ -138,9 +138,9 @@ public enum NIOMPLEXErrors {
     /// meaningfully be `Equatable`, so they aren't. There's also no additional location information: that's
     /// provided by the base error.
     public struct StreamError: Error {
-        private final class Storage {
-            var streamID: MPLEXStreamID
-            var baseError: Error
+        private final class Storage: Sendable {
+            let streamID: MPLEXStreamID
+            let baseError: Error
 
             init(streamID: MPLEXStreamID, baseError: Error) {
                 self.baseError = baseError
@@ -157,29 +157,15 @@ public enum NIOMPLEXErrors {
 
         private var storage: Storage
 
-        private mutating func copyStorageIfNotUniquelyReferenced() {
-            if !isKnownUniquelyReferenced(&self.storage) {
-                self.storage = self.storage.copy()
-            }
-        }
-
         public var baseError: Error {
             get {
                 self.storage.baseError
-            }
-            set {
-                self.copyStorageIfNotUniquelyReferenced()
-                self.storage.baseError = newValue
             }
         }
 
         public var streamID: MPLEXStreamID {
             get {
                 self.storage.streamID
-            }
-            set {
-                self.copyStorageIfNotUniquelyReferenced()
-                self.storage.streamID = newValue
             }
         }
 

--- a/Sources/LibP2PMPLEX/MPLEX/MPLEXStream.swift
+++ b/Sources/LibP2PMPLEX/MPLEX/MPLEXStream.swift
@@ -33,12 +33,12 @@ public final class MPLEXStream: _Stream {
     public let id: UInt64
     public let name: String?
     public let mode: LibP2P.Mode
-    
+
     private let _protocolCodec: NIOLockedValueBox<String>
     public var protocolCodec: String {
         _protocolCodec.withLockedValue { $0 }
     }
-    
+
     public var direction: ConnectionStats.Direction {
         self.mode == .listener ? .inbound : .outbound
     }
@@ -151,7 +151,7 @@ public final class MPLEXStream: _Stream {
 
     internal func updateStreamState(state: StreamState, protocol: String) {
         // Update our state if it's a valid transition...
-        if state.rawValue > self._streamState.withLockedValue({$0}).rawValue {
+        if state.rawValue > self._streamState.withLockedValue({ $0 }).rawValue {
             //print("Stream[\(streamID.id)] -> Updating state from \(self._streamState) -> \(state)")
             self._streamState.withLockedValue { $0 = state }
         }

--- a/Sources/LibP2PMPLEX/MPLEX/MPLEXStream.swift
+++ b/Sources/LibP2PMPLEX/MPLEX/MPLEXStream.swift
@@ -13,35 +13,40 @@
 //===----------------------------------------------------------------------===//
 
 import LibP2P
+import NIOConcurrencyHelpers
 
 /// A BasicStream manages a specific protocol Stream over a Connection. Non Muxed Stream. Only one BasicStream per Connection.
-public class MPLEXStream: _Stream {
+public final class MPLEXStream: _Stream {
     //public private(set) var streamState:LibP2PCore.StreamState
-    public var _streamState: LibP2PCore.StreamState
+    public let _streamState: NIOLockedValueBox<LibP2PCore.StreamState>
     public var streamState: LibP2PCore.StreamState {
-        _streamState
+        _streamState.withLockedValue { $0 }
     }
 
     //public private(set) var connection: Connection?
-    public weak var _connection: Connection?
+    public let _connection: NIOLockedValueBox<Connection?>
     public var connection: Connection? {
-        _connection
+        _connection.withLockedValue { $0 }
     }
 
     public let channel: Channel
     public let id: UInt64
     public let name: String?
     public let mode: LibP2P.Mode
-    public private(set) var protocolCodec: String
-
+    
+    private let _protocolCodec: NIOLockedValueBox<String>
+    public var protocolCodec: String {
+        _protocolCodec.withLockedValue { $0 }
+    }
+    
     public var direction: ConnectionStats.Direction {
         self.mode == .listener ? .inbound : .outbound
     }
 
     private let streamID: MPLEXStreamID
-    //    public  lazy var eventLoop:EventLoop = {
-    //        channel.eventLoop
-    //    }()
+    //public  lazy var eventLoop:EventLoop = {
+    //    channel.eventLoop
+    //}()
 
     public required init(
         channel: Channel,
@@ -55,12 +60,12 @@ public class MPLEXStream: _Stream {
         self.mode = mode
         self.id = id
         self.name = name
-        self._streamState = streamState
-        self.protocolCodec = proto
+        self._streamState = .init(streamState)
+        self._protocolCodec = .init(proto)
 
         self.streamID = MPLEXStreamID(id: id, mode: mode)
-
-        self.on = nil
+        self._connection = .init(nil)
+        self._on = .init(nil)
         //print("Stream[\(id)]::Initializing")
     }
 
@@ -69,10 +74,15 @@ public class MPLEXStream: _Stream {
     //}
 
     /// Main Delegate/Callback Function
-    public var on: ((LibP2PCore.StreamEvent) -> EventLoopFuture<Void>)?
+    public typealias EventCallback = (@Sendable (LibP2PCore.StreamEvent) -> EventLoopFuture<Void>)?
+    private let _on: NIOLockedValueBox<EventCallback>
+    public var on: EventCallback {
+        get { _on.withLockedValue { $0 } }
+        set { _on.withLockedValue { $0 = newValue } }
+    }
 
     public func write(_ data: Data) -> EventLoopFuture<Void> {
-        self.write(channel.allocator.buffer(bytes: data.bytes))
+        self.write(channel.allocator.buffer(bytes: data.byteArray))
     }
 
     public func write(_ bytes: [UInt8]) -> EventLoopFuture<Void> {
@@ -85,14 +95,14 @@ public class MPLEXStream: _Stream {
 
         //print("Stream[\(streamID.id)] -> Attempting to write to channel")
         guard self.channel.isActive && self.channel.isWritable else {
-            self._streamState = .reset
+            self._streamState.withLockedValue { $0 = .reset }
             return self.channel.eventLoop.makeFailedFuture(Errors.streamNotWritable)
         }
         guard self.streamState == .open else {
             return self.channel.eventLoop.makeFailedFuture(Errors.streamNotWritable)
         }
         // Write it out
-        self.channel.writeAndFlush(NIOAny(RawResponse(payload: buffer)), promise: nil)
+        self.channel.writeAndFlush(RawResponse(payload: buffer), promise: nil)
         //self.channel.writeAndFlush(NIOAny(MPLEXFrame(streamID: streamID, payload: .outboundData(buffer))), promise: nil)
         return self.channel.eventLoop.makeSucceededVoidFuture()
         //return promise.futureResult
@@ -101,11 +111,11 @@ public class MPLEXStream: _Stream {
     /// Sends a close stream message to our remote peer, requesting this Stream be closed.
     /// - Note: Because there can be multiple MPLEXStreams over a single Connection, this will NOT close the underlying Connection.
     public func close(gracefully: Bool) -> EventLoopFuture<Void> {
-        switch self._streamState {
+        switch self._streamState.withLockedValue({ $0 }) {
         case .initialized, .open:
-            self._streamState = .writeClosed
+            self._streamState.withLockedValue { $0 = .writeClosed }
         case .receiveClosed:
-            self._streamState = .closed
+            self._streamState.withLockedValue { $0 = .closed }
         case .writeClosed, .closed, .reset:
             return self.channel.eventLoop.makeSucceededVoidFuture()
         }
@@ -119,7 +129,7 @@ public class MPLEXStream: _Stream {
         let promise = self.channel.eventLoop.makePromise(of: Void.self)
         if self.channel.isActive && self.channel.isWritable {
             print("Stream[\(streamID.id)] -> Writing Reset Message")
-            self.channel.writeAndFlush(NIOAny(MPLEXFrame(streamID: streamID, payload: .reset)), promise: nil)
+            self.channel.writeAndFlush(MPLEXFrame(streamID: streamID, payload: .reset), promise: nil)
         } else {
             print("Stream[\(streamID.id)] -> Skipping Reset Message, Channel already closed...")
         }
@@ -127,7 +137,7 @@ public class MPLEXStream: _Stream {
         //            print("Stream[\(self.streamID.id)] -> Reseting")
         //            self.channel.close(mode: .all, promise: nil)
         //        }
-        self._streamState = .reset
+        self._streamState.withLockedValue { $0 = .reset }
         self.channel.close(mode: .all, promise: promise)
         return promise.futureResult
     }
@@ -141,9 +151,9 @@ public class MPLEXStream: _Stream {
 
     internal func updateStreamState(state: StreamState, protocol: String) {
         // Update our state if it's a valid transition...
-        if state.rawValue > self._streamState.rawValue {
+        if state.rawValue > self._streamState.withLockedValue({$0}).rawValue {
             //print("Stream[\(streamID.id)] -> Updating state from \(self._streamState) -> \(state)")
-            self._streamState = state
+            self._streamState.withLockedValue { $0 = state }
         }
         //else { print("Stream[\(streamID.id)] -> Skipping invalid state change from \(self._streamState) -> \(state)") }
 
@@ -153,7 +163,7 @@ public class MPLEXStream: _Stream {
             return
         }
         //print("Stream[\(streamID.id)] -> Updating protocol from \(self.protocolCodec) -> \(`protocol`)")
-        self.protocolCodec = `protocol`
+        self._protocolCodec.withLockedValue { $0 = `protocol` }
     }
 
     public enum Errors: Error {

--- a/Sources/LibP2PMPLEX/MPLEX/MPLEXStreamChannel.swift
+++ b/Sources/LibP2PMPLEX/MPLEX/MPLEXStreamChannel.swift
@@ -243,27 +243,18 @@ final class MPLEXStreamChannel: Channel, ChannelCore, @unchecked Sendable {
         parent: Channel,
         multiplexer: MPLEXStreamMultiplexer,
         streamID: MPLEXStreamID?,
-        //targetWindowSize: Int32,
-        //outboundBytesHighWatermark: Int,
-        //outboundBytesLowWatermark: Int,
         streamDataType: MPLEXStreamDataType
     ) {
         self.allocator = allocator
         self.closePromise = parent.eventLoop.makePromise()
-        //self.localAddress = parent.localAddress
-        //self.remoteAddress = parent.remoteAddress
         self.parent = parent
         self.eventLoop = parent.eventLoop
         self.streamID = streamID
         self.multiplexer = multiplexer
-        //self.windowManager = InboundWindowManager(targetSize: Int32(targetWindowSize))
         self._isActiveAtomic = .makeAtomic(value: false)
         self._isWritable = .makeAtomic(value: true)
         self.state = .idle
         self.streamDataType = streamDataType
-        //self.writabilityManager = MPLEXStreamChannelFlowController(highWatermark: outboundBytesHighWatermark,
-        //                                                      lowWatermark: outboundBytesLowWatermark,
-        //                                                      parentIsWritable: parent.isWritable)
 
         // To begin with we initialize autoRead to false, but we are going to fetch it from our parent before we
         // go much further.

--- a/Sources/LibP2PMPLEX/MPLEX/MPLEXStreamChannel.swift
+++ b/Sources/LibP2PMPLEX/MPLEX/MPLEXStreamChannel.swift
@@ -130,12 +130,12 @@ private enum StreamChannelState {
     }
 }
 
-public struct MPLEXFrame: Equatable {
+public struct MPLEXFrame: Equatable, Sendable {
     /// The streams ID
-    var streamID: MPLEXStreamID
+    let streamID: MPLEXStreamID
 
     /// The payload of this frame
-    var payload: FramePayload
+    let payload: FramePayload
 
     enum FramePayload: Equatable {
         case inboundData(ByteBuffer)

--- a/Tests/LibP2PMPLEXTests/FrameDecoderTests.swift
+++ b/Tests/LibP2PMPLEXTests/FrameDecoderTests.swift
@@ -14,14 +14,15 @@
 
 import LibP2P
 import NIOTestUtils
-import XCTest
+import Testing
 
 @testable import LibP2PMPLEX
 
-final class LibP2PMPLEXTests: XCTestCase {
+@Suite("Libp2p MPLEX Tests")
+struct LibP2PMPLEXTests {
 
     /// A few newStream MPLEXFrames
-    func testMPLEXFrameDecoderNewStreams() throws {
+    @Test func testMPLEXFrameDecoderNewStreams() throws {
         let inboundData: [UInt8] = [
             0x88, 0x01, 0x02, 0x31, 0x37, 0x98, 0x01, 0x02, 0x31, 0x39, 0xa8, 0x01, 0x02, 0x32, 0x31,
         ]
@@ -43,18 +44,18 @@ final class LibP2PMPLEXTests: XCTestCase {
             )
         ]
 
-        XCTAssertNoThrow(
+        #expect(throws: Never.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: exepectedInOuts,
                 decoderFactory: { MPLEXFrameDecoder() }
             )
-        )
+        }
     }
 
     /// This is a recording of all the inbound bytes sent during an echo request using GO's echo example
     /// - Multistream, PlaintextV2, MPLEX
     /// - /echo/1.0.0 protocol
-    func testMPLEXFrameDecoderGoEchoReplay() throws {
+    @Test func testMPLEXFrameDecoderGoEchoReplay() throws {
         let inboundHex =
             "0001300224132f6d756c746973747265616d2f312e302e300a0f2f697066732f69642f312e302e300a0114132f6d756c746973747265616d2f312e302e300a0914132f6d756c746973747265616d2f312e302e300a010d0c2f6563686f2f312e302e300a09100f2f697066732f69642f312e302e300a09c308c1080aab02080012a60230820122300d06092a864886f70d01010105000382010f003082010a0282010100bc012529f27a56372766b242283c295ca6e01245b4ef6a4d7f6dea098053ae9ebbe96690122e738da9987e24360a65c760455ac66505d6809d964a2c0847edcde8e38d58e671ca9d5f0103f8d200b150883dc1dd4f696e0655d12768b681070f2d0688e97b7d7fba2997d83c28af843662a7dac16f847bf797a5a56d6c00856101edd8a424ea478b1223653d666c6c27ab68767491be63c7d4edade0e5ea81d3a6728bf5c967a0a3cc03a4fd080e9b575c91be1b4bace26a6203c03df9282cb684e4428a235ed45b8e9e59bd743766e970adf0778ed46278b30010c4935d1c40bd6b969ebabf118e3ae152eb7dafa1557b04cfa5d6985b02222a9933a680f42502030100011208047f0000010627101a132f7032702f69642f64656c74612f312e302e301a0e2f697066732f69642f312e302e301a132f697066732f69642f707573682f312e302e301a102f697066732f70696e672f312e302e301a0b2f6563686f2f312e302e302208047f00000106e0ad2a0a697066732f302e312e3032246769746875622e636f6d2f6c69627032702f676f2d6c69627032702f6578616d706c657342f1040aab02080012a60230820122300d06092a864886f70d01010105000382010f003082010a0282010100bc012529f27a56372766b242283c295ca6e01245b4ef6a4d7f6dea098053ae9ebbe96690122e738da9987e24360a65c760455ac66505d6809d964a2c0847edcde8e38d58e671ca9d5f0103f8d200b150883dc1dd4f696e0655d12768b681070f2d0688e97b7d7fba2997d83c28af843662a7dac16f847bf797a5a56d6c00856101edd8a424ea478b1223653d666c6c27ab68767491be63c7d4edade0e5ea81d3a6728bf5c967a0a3cc03a4fd080e9b575c91be1b4bace26a6203c03df9282cb684e4428a235ed45b8e9e59bd743766e970adf0778ed46278b30010c4935d1c40bd6b969ebabf118e3ae152eb7dafa1557b04cfa5d6985b02222a9933a680f4250203010001120203011a3a0a22122069849906f7fc9053e2e7d7331d701fe700cfedcc0438f77b4154ce4bf65b4b6c108892d3f2b7b0f0f5161a0a0a08047f0000010627102a80025f22482bf15d571a5e5c1938bbf4d7614c8884da53ee98b28312a75c18fc79d357a4ccf6209d1c53e6b21db94ebedadec4537230d06cbed04bdbc75582cca88d03b0cae5928c228ec7a356de046d3743efcc7148c25b03335bac7ffd26ead0cd468d1e31a7df3854f0fbcacb7e9e168b5d1bc6484aeeaa19ab1400e346f4074ef5050502d47698a139f3eed6f93ea9380135c65b8a9524c979dd65d319fbdb52cb20f5d4c465308d5297b5077b413178c2664cf13c83279fdfdcebb0044e0778df7dadfe66d372bc14b9c8000368706f76ee1d08508fecaedf81deaabe3c9fff225d97241183eb07f93e2f4920cb58c6ff750127db0d858b3e943a89d18a11160b00011348656c6c6f205377696674204c69625032500a03000400"
 
@@ -129,16 +130,11 @@ final class LibP2PMPLEXTests: XCTestCase {
             )
         ]
 
-        XCTAssertNoThrow(
+        #expect(throws: Never.self) {
             try ByteToMessageDecoderVerifier.verifyDecoder(
                 inputOutputPairs: exepectedInOuts,
                 decoderFactory: { MPLEXFrameDecoder() }
             )
-        )
+        }
     }
-
-    static var allTests = [
-        ("testMPLEXFrameDecoderNewStreams", testMPLEXFrameDecoderNewStreams),
-        ("testMPLEXFrameDecoderGoEchoReplay", testMPLEXFrameDecoderGoEchoReplay),
-    ]
 }


### PR DESCRIPTION
### What
- Bumps spm to 6.0 ([libp2p will start supporting the latest 3 versions of swift similar to swift-nio](https://github.com/apple/swift-nio?tab=readme-ov-file#swift-versions))
- Migrates from `XCTest` to [Testing](https://github.com/swiftlang/swift-testing)
- Adds `Sendable` conformance to necessary types

### Breaking Changes
> [!WARNING]
> - `MPLEXStreamChannel` uses @unchecked Sendable. But it *should* be thread safe due to it existing on a single `EventLoop` at a time.
> - This PR requires a minor version bump and depends on the +0.2.0 series of support dependencies and +0.3.0 of swift-libp2p